### PR TITLE
Code Quality Improvement - Empty arrays and collections should be returned instead of null

### DIFF
--- a/src/main/java/com/alibaba/mtc/MtContextCallable.java
+++ b/src/main/java/com/alibaba/mtc/MtContextCallable.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Collections;
 
 /**
  * {@link MtContextCallable} decorate {@link Callable}, so as to get {@link MtContextThreadLocal}
@@ -128,7 +129,7 @@ public final class MtContextCallable<V> implements Callable<V> {
      */
     public static <T> List<MtContextCallable<T>> gets(Collection<? extends Callable<T>> tasks, boolean releaseMtContextAfterCall) {
         if (null == tasks) {
-            return null;
+            return Collections.emptyList();
         }
         List<MtContextCallable<T>> copy = new ArrayList<MtContextCallable<T>>();
         for (Callable<T> task : tasks) {
@@ -147,7 +148,7 @@ public final class MtContextCallable<V> implements Callable<V> {
      */
     public static <T> List<MtContextCallable<T>> gets(Collection<? extends Callable<T>> tasks, boolean releaseMtContextAfterCall, boolean idempotent) {
         if (null == tasks) {
-            return null;
+            return Collections.emptyList();
         }
         List<MtContextCallable<T>> copy = new ArrayList<MtContextCallable<T>>();
         for (Callable<T> task : tasks) {

--- a/src/main/java/com/alibaba/mtc/MtContextRunnable.java
+++ b/src/main/java/com/alibaba/mtc/MtContextRunnable.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Collections;
 
 /**
  * {@link MtContextRunnable} decorate {@link Runnable}, so as to get {@link MtContextThreadLocal}
@@ -132,7 +133,7 @@ public final class MtContextRunnable implements Runnable {
      */
     public static List<MtContextRunnable> gets(Collection<? extends Runnable> tasks, boolean releaseMtContextAfterRun) {
         if (null == tasks) {
-            return null;
+            return Collections.emptyList();
         }
         List<MtContextRunnable> copy = new ArrayList<MtContextRunnable>();
         for (Runnable task : tasks) {
@@ -153,7 +154,7 @@ public final class MtContextRunnable implements Runnable {
      */
     public static List<MtContextRunnable> gets(Collection<? extends Runnable> tasks, boolean releaseMtContextAfterRun, boolean idempotent) {
         if (null == tasks) {
-            return null;
+            return Collections.emptyList();
         }
         List<MtContextRunnable> copy = new ArrayList<MtContextRunnable>();
         for (Runnable task : tasks) {

--- a/src/main/java/com/alibaba/mtc/threadpool/agent/MtContextTransformer.java
+++ b/src/main/java/com/alibaba/mtc/threadpool/agent/MtContextTransformer.java
@@ -37,6 +37,7 @@ public class MtContextTransformer implements ClassFileTransformer {
     private static final String SCHEDULER_CLASS_FILE = "java.util.concurrent.ScheduledThreadPoolExecutor".replace('.', '/');
 
     private static final String TIMER_TASK_CLASS_FILE = "java.util.TimerTask".replace('.', '/');
+    private static final byte[] EMPTY_BYTE_ARRAY = {};
 
     private static String toClassName(String classFile) {
         return classFile.replace('/', '.');
@@ -65,7 +66,7 @@ public class MtContextTransformer implements ClassFileTransformer {
                     if (TIMER_TASK_CLASS_FILE.equals(name)) {
                         logger.info("Transforming class " + className);
                         // FIXME add code here
-                        return null;
+                        return EMPTY_BYTE_ARRAY;
                     }
                 }
             }
@@ -74,7 +75,7 @@ public class MtContextTransformer implements ClassFileTransformer {
             logger.severe(msg);
             throw new IllegalStateException(msg, t);
         }
-        return null;
+        return EMPTY_BYTE_ARRAY;
     }
 
     private CtClass getCtClass(byte[] classFileBuffer, ClassLoader classLoader) throws IOException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1168 - “Empty arrays and collections should be returned instead of null”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1168.

Please let me know if you have any questions.

Christian Ivan.